### PR TITLE
Fix divison bug in xccp.c

### DIFF
--- a/src/xccp.c
+++ b/src/xccp.c
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
 			printstr = "(%d, %d, %d)\n";
 
 		/* print colors in determined format (hex, HEX or rgb) */
-		printf(printstr, color.red/255, color.green/255, color.blue/255);
+		printf(printstr, color.red/256, color.green/256, color.blue/256);
 	} while(args & ARG_CONTINUE); /* if continuous mode is given via args, repeat */
 	
 cleanup:


### PR DESCRIPTION
While trying out this cool little C project, I realized it was output hex codes longer than 6 digits. It turns out that because xccp was dividing the X11 color by `255` rather than `256`, it was outputting larger than numbers than 256.

An example of this is the color `(129, 154, 255)`. I was getting the output `(130, 155, 257)` from xccp.

My change should fix the bug, but it may be desirable to bound the division.

Reference: https://stackoverflow.com/questions/17518610/how-to-get-a-screen-pixels-color-in-x11

Thanks. Have a great day.